### PR TITLE
bug fix: During wakeup, re-enable SOF interrupt

### DIFF
--- a/src/stm32f0xx_hal_pcd.c
+++ b/src/stm32f0xx_hal_pcd.c
@@ -576,7 +576,7 @@ void HAL_PCD_IRQHandler(PCD_HandleTypeDef *hpcd)
 
     /*set wInterrupt_Mask global variable*/
     wInterrupt_Mask = USB_CNTR_CTRM  | USB_CNTR_WKUPM | USB_CNTR_SUSPM | USB_CNTR_ERRM \
-      | USB_CNTR_ESOFM | USB_CNTR_RESETM;
+      | USB_CNTR_ESOFM | USB_CNTR_RESETM | USB_CNTR_SOFM;
     
     /*Set interrupt mask*/
     hpcd->Instance->CNTR = wInterrupt_Mask;
@@ -591,7 +591,6 @@ void HAL_PCD_IRQHandler(PCD_HandleTypeDef *hpcd)
     /* clear of the ISTR bit must be done after setting of CNTR_FSUSP */
     __HAL_PCD_CLEAR_FLAG(hpcd, USB_ISTR_SUSP);  
     
-#if 0 /* MODIFIED: when enabled, CDC latency is painfully choppy */
     /* Force low-power mode in the macrocell */
     hpcd->Instance->CNTR |= USB_CNTR_FSUSP;
     hpcd->Instance->CNTR |= USB_CNTR_LPMODE;
@@ -600,7 +599,6 @@ void HAL_PCD_IRQHandler(PCD_HandleTypeDef *hpcd)
     {
       HAL_PCD_SuspendCallback(hpcd);
     }
-#endif
   }
 
   if (__HAL_PCD_GET_FLAG (hpcd, USB_ISTR_SOF))


### PR DESCRIPTION
This mitigates the need for the hack of disabling USB suspend.  During
a suspend/resume cycle, the device disabled the SOF interrupt, and
the SOF interrupt is the primary way the device communicated outgoing
data to the PC.